### PR TITLE
Account view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
         "react-signify": "^1.5.1",
         "react-toastify": "^11.0.5",
         "recharts": "^2.15.3",
+        "sweetalert2": "^11.22.0",
+        "sweetalert2-react-content": "^5.1.0",
         "web-vitals": "^2.1.4"
       }
     },
@@ -18016,6 +18018,27 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/sweetalert2": {
+      "version": "11.22.0",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.22.0.tgz",
+      "integrity": "sha512-pSMuRGDULhh+wrFkO22O0YsIXxs8yFE0O+WVYXcqc/sTa1oRnf0JlR+vfQIRY1QM1UeFfnCjyw6DYnG75/oxiQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/limonte"
+      }
+    },
+    "node_modules/sweetalert2-react-content": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/sweetalert2-react-content/-/sweetalert2-react-content-5.1.0.tgz",
+      "integrity": "sha512-SBh41SdyHDY9NzwrIG6LACbClCMxIlEFP86tGVr/B4zGD4H2gGXB8o7UAJRc/RtBd/iQL9hIvuCAkrk0AgKEMA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "sweetalert2": "^11.0.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "react-signify": "^1.5.1",
     "react-toastify": "^11.0.5",
     "recharts": "^2.15.3",
+    "sweetalert2": "^11.22.0",
+    "sweetalert2-react-content": "^5.1.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/app/layouts/adminLayout/AdminLayout/AdminLayout.js
+++ b/src/app/layouts/adminLayout/AdminLayout/AdminLayout.js
@@ -1,19 +1,29 @@
-import React from "react";
+import React, { useState } from "react";
 import "./AdminLayout.css";
 import Navigation from "../Navigation";
 import AdminHeader from "../Header";
 import { Outlet } from "react-router-dom";
 
+export const AdminTitleContext = React.createContext();
+
 export default function AdminLayout() {
+
+  const [title, setTitle] = useState("Trang quản trị");
+  const [subtitle, setSubtitle] = useState("Quản lý hệ thống đặt tour");
+
+
   return (
-    <div className="admin-container">
-      <Navigation />
-      <div className="admin-main">
-        <AdminHeader />
-        <main className="admin-content">
-          <Outlet />
-        </main>
+    <AdminTitleContext.Provider value={{ title, subtitle, setTitle, setSubtitle }}>
+      <div className="admin-container">
+        <Navigation />
+        <div className="admin-main">
+          <AdminHeader />
+          
+          <main className="admin-content">
+            <Outlet />
+          </main>
+        </div>1
       </div>
-    </div>
+     </AdminTitleContext.Provider>
   );
 }

--- a/src/app/layouts/adminLayout/Header/AdminHeader.js
+++ b/src/app/layouts/adminLayout/Header/AdminHeader.js
@@ -3,6 +3,8 @@ import { AdminTitleContext } from "../AdminLayout/AdminLayout";
 import avatar from "../../../assets/images/admin/header/avatar.jpg";
 import "./AdminHeader.css";
 import { useAuth } from "../../../lib/AuthContext";
+import { useNavigate } from "react-router-dom"; // Thêm dòng này
+
 export default function AdminHeader() {
   const { title, subtitle } = useContext(AdminTitleContext);
   const { setIsLoggedIn } = useAuth();
@@ -11,6 +13,7 @@ export default function AdminHeader() {
     setIsOpen(!isOpen);
   };
   const dropdownRef = useRef(null);
+  const navigate = useNavigate(); // Thêm dòng này
 
   // Đóng dropdown khi click ra ngoài
   useEffect(() => {
@@ -30,6 +33,12 @@ export default function AdminHeader() {
     localStorage.removeItem("userId");
     setIsLoggedIn(false);
     window.location.href = "/login"; // Chuyển hướng đến trang đăng nhập
+  };
+
+  // Thêm hàm chuyển hướng
+  const handleAccount = () => {
+    navigate("/account");
+    setIsOpen(false);
   };
 
   return (
@@ -54,7 +63,7 @@ export default function AdminHeader() {
           {isOpen && (
             <div className="dropdown-menu-custom">
               <ul>
-                <li>Thông tin cá nhân</li>
+                <li onClick={handleAccount}>Thông tin cá nhân</li>
                 <li onClick={handleLogout}>Đăng xuất</li>
               </ul>
             </div>

--- a/src/app/layouts/adminLayout/Header/AdminHeader.js
+++ b/src/app/layouts/adminLayout/Header/AdminHeader.js
@@ -1,8 +1,10 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, useContext } from "react";
+import { AdminTitleContext } from "../AdminLayout/AdminLayout";
 import avatar from "../../../assets/images/admin/header/avatar.jpg";
 import "./AdminHeader.css";
 import { useAuth } from "../../../lib/AuthContext";
 export default function AdminHeader() {
+  const { title, subtitle } = useContext(AdminTitleContext);
   const { setIsLoggedIn } = useAuth();
   const [isOpen, setIsOpen] = useState(false);
   const toggleDropdown = () => {
@@ -34,8 +36,8 @@ export default function AdminHeader() {
     <header className="header-admin">
       {/* Bên trái */}
       <div className="header-left">
-        <h1 className="title">Tất cả điểm tham quan du lịch</h1>
-        <p className="subtitle">Thông tin tất cả điểm tham quan du lịch</p>
+        <h1 className="title">{title}</h1>
+        <p className="subtitle">{subtitle}</p>
       </div>
 
       {/* Bên phải */}

--- a/src/app/lib/httpHandler.js
+++ b/src/app/lib/httpHandler.js
@@ -1,4 +1,4 @@
-const BE_ENDPOINT = "http://localhost:8080";
+const BE_ENDPOINT = "http://localhost:8081";
 
 const DEFAULT_HEADERS = {
   "Content-Type": "application/json",

--- a/src/app/lib/httpHandler.js
+++ b/src/app/lib/httpHandler.js
@@ -1,4 +1,4 @@
-const BE_ENDPOINT = "http://localhost:8081";
+const BE_ENDPOINT = "http://localhost:8080";
 
 const DEFAULT_HEADERS = {
   "Content-Type": "application/json",

--- a/src/app/pages/Admin/CustomerManagement/CustomerMainPage.js
+++ b/src/app/pages/Admin/CustomerManagement/CustomerMainPage.js
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React, { useState, useContext, useEffect } from "react";
+import { AdminTitleContext } from "../../../layouts/adminLayout/AdminLayout/AdminLayout";
 import "./CustomerMainPage.css";
 import search from "../../../assets/icons/customer/header/search.png";
 import { MdOutlineAddBox } from "react-icons/md";
@@ -9,6 +10,15 @@ import DetailCustomer from "../../../components/Admin/CustomerManagement/DetailC
 import { BE_ENDPOINT, fetchGet, fetchDelete } from "../../../lib/httpHandler";
 
 export default function CustomerMainPage() {
+  const { setTitle, setSubtitle } = useContext(AdminTitleContext);
+
+  useEffect(() => {
+    setTitle("Tất cả khách hàng");
+    setSubtitle("Thông tin tất cả khách hàng");
+  }, [setTitle, setSubtitle]);
+
+
+
   const [showAdd, setShowAdd] = useState(false);
   const [showDetail, setShowDetail] = useState(false);
   const [customers, setCustomers] = useState([]);

--- a/src/app/pages/Admin/Dashboard/Dashboard.js
+++ b/src/app/pages/Admin/Dashboard/Dashboard.js
@@ -256,15 +256,15 @@ export default function Dashboard() {
           <button className="fav-places-btn-centered">Xem toàn bộ</button>
         </div>
           <div className="fav-places-grid">
-  {favoritePlaces.map((place, idx) => (
-    <div className="fav-place-img-wrap" key={idx}>
-      <img src={place.image} alt={place.name} />
-      <div className="fav-place-overlay">
-        <span>{place.name}</span>
-      </div>
-    </div>
-  ))}
-</div>
+            {favoritePlaces.map((place, idx) => (
+              <div className="fav-place-img-wrap" key={idx}>
+                <img src={place.image} alt={place.name} />
+                <div className="fav-place-overlay">
+                  <span>{place.name}</span>
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/pages/Admin/Dashboard/Dashboard.js
+++ b/src/app/pages/Admin/Dashboard/Dashboard.js
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useState, useContext, useEffect } from "react";
+import { AdminTitleContext } from "../../../layouts/adminLayout/AdminLayout/AdminLayout";
 import "./Dashboard.css";
 import CalendarLogo from "../../../assets/icons/admin/DashBoard/calendar-heart-01.svg";
 
@@ -165,6 +166,14 @@ function Calendar({ year, month, tripDays }) {
 }
 
 export default function Dashboard() {
+  const { setTitle, setSubtitle } = useContext(AdminTitleContext);
+  
+    useEffect(() => {
+      setTitle("Trang chủ");
+      setSubtitle("Thông tin tổng quan hệ thống");
+    }, [setTitle, setSubtitle]);
+
+
   const today = new Date();
   const year = today.getFullYear();
   const month = 3; // Tháng 3 (March)

--- a/src/app/pages/Admin/DestinationManagement/DestinationMainPage.js
+++ b/src/app/pages/Admin/DestinationManagement/DestinationMainPage.js
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useState, useContext, useEffect } from "react";
+import { AdminTitleContext } from "../../../layouts/adminLayout/AdminLayout/AdminLayout";
 import "./DestinationMainPage.css";
 import search from "../../../assets/icons/customer/header/search.png";
 import { MdOutlineAddBox } from "react-icons/md";
@@ -8,6 +9,13 @@ import AddDestination from "../../../components/Admin/DestinationManagement/AddD
 import DetailDestination from "../../../components/Admin/DestinationManagement/DetailDestination/DetailDestination";
 
 export default function DestinationMainPage() {
+  const { setTitle, setSubtitle } = useContext(AdminTitleContext);
+
+  useEffect(() => {
+    setTitle("Tất cả điểm tham quan du lịch");
+    setSubtitle("Thông tin tất cả điểm tham quan du lịch");
+  }, [setTitle, setSubtitle]);
+
   const [showAddDes, setShowAddDes] = useState(false);
   const [showDetailDes, setShowDetailDes] = useState(false);
 

--- a/src/app/pages/Admin/Report/Report.js
+++ b/src/app/pages/Admin/Report/Report.js
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React, { useState, useContext, useEffect } from "react";
+import { AdminTitleContext } from "../../../layouts/adminLayout/AdminLayout/AdminLayout";
 import {
   BarChart,
   Bar,
@@ -56,6 +57,13 @@ function getMonthOfWeek(week, quarter) {
 }
 
 export default function Report() {
+  const { setTitle, setSubtitle } = useContext(AdminTitleContext);
+
+  useEffect(() => {
+    setTitle("Báo cáo doanh thu & số lượng đặt tour");
+    setSubtitle("Xem báo cáo doanh thu và số lượng đặt tour theo quý");
+  }, [setTitle, setSubtitle]);
+
   const [quarter, setQuarter] = useState(1);
   const [year, setYear] = useState(new Date().getFullYear());
   const [data, setData] = useState([]);

--- a/src/app/pages/Other/Account/Account.css
+++ b/src/app/pages/Other/Account/Account.css
@@ -1,0 +1,256 @@
+.account-container {
+  background: #fff;
+  border-radius: 16px;
+  padding: 32px;
+  max-width: 900px;
+  margin: 32px auto;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.07);
+}
+
+.account-header-title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 28px;
+  text-align: center;
+  color: #c34141;
+  letter-spacing: 1px;
+}
+
+.info-block {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+  padding: 24px 24px 0 24px;
+  margin-bottom: 32px;
+}
+
+.info-block-header {
+  display: flex;
+  align-items: center;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #c34141;
+  margin-bottom: 18px;
+  gap: 10px;
+}
+
+.info-block-header .icon-btn {
+  margin-left: 10px;
+  font-size: 1.2rem;
+  padding: 6px 12px;
+}
+
+.account-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  align-items: stretch;
+  margin-bottom: 0;
+}
+
+.avatar-section {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 18px;
+}
+
+.avatar-wrapper {
+  position: relative;
+  width: 120px;
+  height: 120px;
+}
+
+.avatar-img {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid #eee;
+  background: #fafafa;
+}
+
+.avatar-edit-btn {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  background: #fff;
+  border: 1.5px solid #c34141;
+  color: #c34141;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 1.3rem;
+  transition: background 0.2s;
+  z-index: 2;
+}
+.avatar-edit-btn:hover {
+  background: #eaf2ff;
+}
+
+.info-section {
+  flex: 1;
+}
+
+.info-row {
+  display: flex;
+  gap: 24px;
+  margin-bottom: 16px;
+}
+
+.info-row > div {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.info-section label {
+  font-size: 14px;
+  color: #555;
+  margin-bottom: 4px;
+}
+
+.info-section input,
+.info-section select {
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 15px;
+  background: #fafafa;
+}
+
+.info-section input:disabled,
+.info-section select:disabled {
+  background: #f5f5f5;
+  color: #aaa;
+}
+
+.info-actions {
+  margin-top: 12px;
+}
+
+.info-actions button,
+.account-actions button {
+  margin-right: 12px;
+  padding: 8px 18px;
+  border-radius: 6px;
+  border: none;
+  background: #c34141;
+  color: #fff;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.info-actions button:last-child,
+.account-actions button:last-child {
+  background: #eee;
+  color: #333;
+}
+
+.icon-btn {
+  background: #fff;
+  color: #c34141;
+  border: 1.5px solid #c34141;
+  padding: 7px 13px;
+  border-radius: 6px;
+  font-size: 1.2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s;
+}
+.icon-btn:hover {
+  background: #eaf2ff;
+}
+
+.account-section {
+  border: 1.5px solid #f3bcbc;
+  border-radius: 12px;
+  padding: 24px;
+  background: #fff7f7;
+  margin-bottom: 32px;
+}
+
+.account-section .info-block-header {
+  margin-bottom: 18px;
+}
+
+.account-title {
+  color: #e74c3c;
+  font-weight: 700;
+  font-size: 18px;
+  margin-bottom: 16px;
+}
+
+.account-form > div {
+  margin-bottom: 14px;
+  display: flex;
+  flex-direction: column;
+}
+
+.account-form label {
+  font-size: 14px;
+  color: #555;
+  margin-bottom: 4px;
+}
+
+.account-form input {
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 15px;
+  background: #fafafa;
+}
+
+.account-form input:disabled {
+  background: #f5f5f5;
+  color: #aaa;
+}
+
+.account-actions {
+  margin-top: 8px;
+}
+
+.password-input-group {
+  margin-bottom: 14px;
+  display: flex;
+  flex-direction: column;
+}
+
+.password-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.password-input-wrapper input {
+  width: 100%;
+  padding-right: 70px;
+}
+
+.password-eye, .password-clear {
+  position: absolute;
+  right: 36px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #888;
+  font-size: 1.25rem;
+  cursor: pointer;
+  z-index: 2;
+  background: transparent;
+  border: none;
+  padding: 0 4px;
+}
+
+.password-clear {
+  right: 8px;
+  color: #e74c3c;
+}
+
+.password-eye:hover, .password-clear:hover {
+  color: #c34141;
+}

--- a/src/app/pages/Other/Account/Account.js
+++ b/src/app/pages/Other/Account/Account.js
@@ -1,0 +1,566 @@
+import { useEffect, useRef, useState } from "react";
+import "./Account.css";
+import { fetchPost, fetchPut, fetchUpload, BE_ENDPOINT } from "../../../lib/httpHandler";
+import { AiOutlineCamera, AiOutlineEye, AiOutlineEyeInvisible, AiOutlineCloseCircle } from "react-icons/ai";
+import { PiPencilSimpleLineBold } from "react-icons/pi";
+import Swal from "sweetalert2";
+import withReactContent from "sweetalert2-react-content";
+
+const MySwal = withReactContent(Swal);
+
+export default function Account() {
+  const userId = localStorage.getItem("userId");
+  const [user, setUser] = useState(null);
+  const [account, setAccount] = useState(null);
+
+  const [editInfo, setEditInfo] = useState(false);
+  const [editAccount, setEditAccount] = useState(false);
+
+  const [info, setInfo] = useState({
+    fullname: "",
+    sex: true,
+    birthday: "",
+    email: "",
+    phoneNumber: "",
+    address: "",
+    avatar: "",
+    account_id: "",
+  });
+
+  const [avatarFile, setAvatarFile] = useState(null);
+  const [avatarPreview, setAvatarPreview] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const [accountInfo, setAccountInfo] = useState({
+    username: "",
+    newPassword: "",
+    confirmPassword: "",
+  });
+
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  const avatarInputRef = useRef();
+
+  useEffect(() => {
+    if (!userId) return;
+    fetchPost(
+      `/api/admin/user/get/${userId}`,
+      {},
+      (res) => {
+        setUser(res.data);
+        setInfo({
+          fullname: res.data.fullname || "",
+          sex: res.data.sex,
+          birthday: res.data.birthday || "",
+          email: res.data.email || "",
+          phoneNumber: res.data.phoneNumber || "",
+          address: res.data.address || "",
+          avatar: res.data.avatar || "",
+          account_id: res.data.account_id,
+        });
+        setAvatarPreview(
+          res.data.avatar
+            ? res.data.avatar.startsWith("http")
+              ? res.data.avatar
+              : BE_ENDPOINT + res.data.avatar
+            : "https://via.placeholder.com/120"
+        );
+        fetchPost(
+          `/api/admin/account/get/${res.data.account_id}`,
+          {},
+          (accRes) => {
+            setAccount(accRes.data);
+            setAccountInfo({
+              username: accRes.data.username,
+              newPassword: "",
+              confirmPassword: "",
+            });
+          },
+          () => MySwal.fire({ icon: "error", title: "Lỗi", text: "Không lấy được thông tin tài khoản" })
+        );
+      },
+      () => MySwal.fire({ icon: "error", title: "Lỗi", text: "Không lấy được thông tin user" })
+    );
+  }, [userId]);
+
+  const handleSaveInfo = async () => {
+    if (!info.fullname || !info.email || !info.phoneNumber || !info.birthday || !info.address) {
+      MySwal.fire({ icon: "error", title: "Lỗi", text: "Vui lòng nhập đầy đủ thông tin" });
+      return;
+    }
+    if (!/^\d{10}$/.test(info.phoneNumber)) {
+      MySwal.fire({ icon: "error", title: "Lỗi", text: "Số điện thoại phải đủ 10 số" });
+      return;
+    }
+    setLoading(true);
+    fetchPut(
+      `/api/admin/user/update/${userId}`,
+      info,
+      (res) => {
+        if (avatarFile) {
+          const formData = new FormData();
+          formData.append("file", avatarFile);
+          fetchUpload(
+            `/api/admin/user/update-avatar/${userId}`,
+            formData,
+            (res2) => {
+              setUser({ ...res.data, avatar: res2.data });
+              setInfo((prev) => ({ ...prev, avatar: res2.data }));
+              setAvatarPreview(
+                res2.data.startsWith("http") ? res2.data : BE_ENDPOINT + res2.data
+              );
+              setAvatarFile(null);
+              setEditInfo(false);
+              setLoading(false);
+              MySwal.fire({
+                icon: "success",
+                title: "Thành công",
+                text: "Cập nhật thông tin thành công",
+                timer: 2000,
+                showConfirmButton: false,
+              });
+            },
+            () => {
+              setLoading(false);
+              MySwal.fire({ icon: "error", title: "Lỗi", text: "Lỗi upload ảnh!" });
+            }
+          );
+        } else {
+          setUser(res.data);
+          setEditInfo(false);
+          setLoading(false);
+          MySwal.fire({
+            icon: "success",
+            title: "Thành công",
+            text: "Cập nhật thông tin thành công",
+            timer: 2000,
+            showConfirmButton: false,
+          });
+        }
+      },
+      () => {
+        setLoading(false);
+        MySwal.fire({ icon: "error", title: "Lỗi", text: "Cập nhật thất bại" });
+      }
+    );
+  };
+
+  // Kiểm tra điều kiện mật khẩu mới
+  const passwordValid = (pw) => {
+    return pw != null && pw.length >= 6 && /[A-Za-z]/.test(pw) && /\d/.test(pw);
+  };
+
+  // Xác thực mật khẩu hiện tại bằng SweetAlert2
+  const confirmCurrentPassword = async () => {
+    let isValid = false;
+    let currentPassword = "";
+    while (!isValid) {
+      const { value: password, isConfirmed, isDismissed } = await MySwal.fire({
+        title: "Xác nhận mật khẩu hiện tại",
+        input: "password",
+        inputLabel: "Nhập mật khẩu hiện tại để xác nhận thay đổi",
+        inputPlaceholder: "Nhập mật khẩu hiện tại",
+        showCancelButton: true,
+        confirmButtonText: "Xác nhận",
+        cancelButtonText: "Hủy",
+        inputAttributes: {
+          autocapitalize: "off",
+          autocorrect: "off",
+        },
+        inputValidator: (value) => {
+          if (!value) {
+            return "Vui lòng nhập mật khẩu hiện tại";
+          }
+        },
+      });
+      if (isDismissed) return null;
+      if (isConfirmed) {
+        currentPassword = password;
+        const result = await new Promise((resolve) => {
+          fetchPost(
+            `/api/admin/account/verify-password`,
+            { accountId: info.account_id, password: currentPassword },
+            (res) => resolve(res.data === true),
+            () => resolve(false)
+          );
+        });
+        if (result) {
+          isValid = true;
+        } else {
+          await MySwal.fire({
+            icon: "error",
+            title: "Sai mật khẩu",
+            text: "Mật khẩu hiện tại không đúng. Vui lòng thử lại.",
+            confirmButtonText: "Thử lại",
+          });
+        }
+      }
+    }
+    return currentPassword;
+  };
+
+  // Sửa tài khoản (username, password)
+  const handleSaveAccount = async () => {
+    if (!accountInfo.username) {
+      MySwal.fire({ icon: "error", title: "Lỗi", text: "Vui lòng nhập tên đăng nhập" });
+      return;
+    }
+    if (!accountInfo.newPassword) {
+      MySwal.fire({ icon: "error", title: "Lỗi", text: "Vui lòng nhập mật khẩu mới" });
+      return;
+    }
+    if (accountInfo.newPassword) {
+      if (!passwordValid(accountInfo.newPassword)) {
+        MySwal.fire({
+          icon: "error",
+          title: "Lỗi",
+          text: "Mật khẩu mới phải tối thiểu 6 ký tự, gồm chữ cái và số",
+        });
+        return;
+      }
+      if (accountInfo.newPassword !== accountInfo.confirmPassword) {
+        MySwal.fire({ icon: "error", title: "Lỗi", text: "Mật khẩu mới không khớp" });
+        return;
+      }
+    }
+    const currentPassword = await confirmCurrentPassword();
+    if (!currentPassword) return;
+    setLoading(true);
+    fetchPut(
+      `/api/admin/account/update/${info.account_id}`,
+      {
+        id: account.id,
+        username: accountInfo.username,
+        password: accountInfo.newPassword ? accountInfo.newPassword : account.password,
+        isLock: account.isLock,
+        currentPassword: currentPassword,
+      },
+      (res) => {
+        setAccount(res.data);
+        setEditAccount(false);
+        setAccountInfo((prev) => ({
+          ...prev,
+          newPassword: "",
+          confirmPassword: "",
+        }));
+        setLoading(false);
+        MySwal.fire({
+          icon: "success",
+          title: "Thành công",
+          text: "Cập nhật tài khoản thành công",
+          timer: 2000,
+          showConfirmButton: false,
+        });
+      },
+      (err) => {
+        setLoading(false);
+        MySwal.fire({
+          icon: "error",
+          title: "Lỗi",
+          text: err.message || "Cập nhật tài khoản thất bại",
+        });
+      }
+    );
+  };
+
+  const handleAvatarChange = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    if (!file.type.startsWith("image/")) {
+      MySwal.fire({ icon: "error", title: "Lỗi", text: "Chỉ chọn file ảnh!" });
+      return;
+    }
+    setAvatarFile(file);
+    setAvatarPreview(URL.createObjectURL(file));
+  };
+
+  const clearNewPassword = () => setAccountInfo((prev) => ({ ...prev, newPassword: "" }));
+  const clearConfirmPassword = () => setAccountInfo((prev) => ({ ...prev, confirmPassword: "" }));
+
+  if (!user || !account) return <div>Đang tải...</div>;
+
+  return (
+    <div className="account-container">
+      <h2 className="account-header-title">Thông tin tài khoản</h2>
+
+      <div className="account-info">
+        <div className="info-block">
+          <div className="info-block-header">
+            <span>Chi tiết thông tin tài khoản</span>
+            {!editInfo && (
+              <button
+                className="icon-btn"
+                title="Sửa thông tin"
+                onClick={() => setEditInfo(true)}
+                type="button"
+              >
+                <PiPencilSimpleLineBold />
+              </button>
+            )}
+          </div>
+          <div className="avatar-section">
+            <div className="avatar-wrapper">
+              <img
+                src={avatarPreview}
+                alt="avatar"
+                className="avatar-img"
+              />
+              {editInfo && (
+                <button
+                  className="avatar-edit-btn"
+                  type="button"
+                  onClick={() => avatarInputRef.current.click()}
+                  title="Đổi ảnh đại diện"
+                >
+                  <AiOutlineCamera />
+                </button>
+              )}
+              <input
+                type="file"
+                accept="image/*"
+                ref={avatarInputRef}
+                style={{ display: "none" }}
+                onChange={handleAvatarChange}
+              />
+            </div>
+          </div>
+          <div className="info-section">
+            <div className="info-row">
+              <div>
+                <label>Họ và tên</label>
+                <input
+                  disabled={!editInfo}
+                  value={info.fullname}
+                  onChange={(e) =>
+                    setInfo({ ...info, fullname: e.target.value })
+                  }
+                />
+              </div>
+              <div>
+                <label>Giới tính</label>
+                <select
+                  disabled={!editInfo}
+                  value={info.sex === true || info.sex === "true" ? "true" : "false"}
+                  onChange={(e) =>
+                    setInfo({ ...info, sex: e.target.value === "true" })
+                  }
+                >
+                  <option value="true">Nam</option>
+                  <option value="false">Nữ</option>
+                </select>
+              </div>
+              <div>
+                <label>Ngày sinh</label>
+                <input
+                  type="date"
+                  disabled={!editInfo}
+                  value={info.birthday}
+                  onChange={(e) =>
+                    setInfo({ ...info, birthday: e.target.value })
+                  }
+                />
+              </div>
+            </div>
+            <div className="info-row">
+              <div>
+                <label>Email</label>
+                <input
+                  disabled={!editInfo}
+                  value={info.email}
+                  onChange={(e) =>
+                    setInfo({ ...info, email: e.target.value })
+                  }
+                />
+              </div>
+              <div>
+                <label>Số điện thoại</label>
+                <input
+                  disabled={!editInfo}
+                  value={info.phoneNumber}
+                  onChange={(e) =>
+                    setInfo({ ...info, phoneNumber: e.target.value })
+                  }
+                  maxLength={10}
+                />
+              </div>
+            </div>
+            <div className="info-row">
+              <div style={{ width: "100%" }}>
+                <label>Địa chỉ</label>
+                <input
+                  disabled={!editInfo}
+                  value={info.address}
+                  onChange={(e) =>
+                    setInfo({ ...info, address: e.target.value })
+                  }
+                />
+              </div>
+            </div>
+            <div className="info-actions">
+              {editInfo && (
+                <>
+                  <button
+                    onClick={handleSaveInfo}
+                    disabled={loading}
+                    type="button"
+                  >
+                    {loading ? "Đang lưu..." : "Lưu"}
+                  </button>
+                  <button
+                    onClick={() => {
+                      setEditInfo(false);
+                      setInfo({
+                        fullname: user.fullname,
+                        sex: user.sex,
+                        birthday: user.birthday,
+                        email: user.email,
+                        phoneNumber: user.phoneNumber,
+                        address: user.address,
+                        avatar: user.avatar,
+                        account_id: user.account_id,
+                      });
+                      setAvatarFile(null);
+                      setAvatarPreview(
+                        user.avatar
+                          ? user.avatar.startsWith("http")
+                            ? user.avatar
+                            : BE_ENDPOINT + user.avatar
+                          : "https://via.placeholder.com/120"
+                      );
+                    }}
+                    type="button"
+                    disabled={loading}
+                  >
+                    Hủy
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="account-section">
+        <div className="info-block-header">
+          <span>Tên đăng nhập &amp; mật khẩu</span>
+          {!editAccount && (
+            <button
+              className="icon-btn"
+              title="Sửa tài khoản"
+              onClick={() => setEditAccount(true)}
+              type="button"
+            >
+              <PiPencilSimpleLineBold />
+            </button>
+          )}
+        </div>
+        <div className="account-form">
+          <div>
+            <label>Tên đăng nhập</label>
+            <input
+              disabled={!editAccount}
+              value={accountInfo.username}
+              onChange={(e) =>
+                setAccountInfo({ ...accountInfo, username: e.target.value })
+              }
+            />
+          </div>
+          <div className="password-input-group">
+            <label>Mật khẩu mới</label>
+            <div className="password-input-wrapper">
+              <input
+                type={showNewPassword ? "text" : "password"}
+                disabled={!editAccount}
+                value={accountInfo.newPassword}
+                onChange={(e) =>
+                  setAccountInfo({ ...accountInfo, newPassword: e.target.value })
+                }
+              />
+              {editAccount && (
+                <>
+                  <span
+                    className="password-eye"
+                    onClick={() => setShowNewPassword((v) => !v)}
+                    title={showNewPassword ? "Ẩn mật khẩu" : "Hiện mật khẩu"}
+                  >
+                    {showNewPassword ? <AiOutlineEyeInvisible /> : <AiOutlineEye />}
+                  </span>
+                  {accountInfo.newPassword && (
+                    <span
+                      className="password-clear"
+                      onClick={clearNewPassword}
+                      title="Xóa mật khẩu"
+                    >
+                      <AiOutlineCloseCircle />
+                    </span>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+          <div className="password-input-group">
+            <label>Nhập lại mật khẩu mới</label>
+            <div className="password-input-wrapper">
+              <input
+                type={showConfirmPassword ? "text" : "password"}
+                disabled={!editAccount}
+                value={accountInfo.confirmPassword}
+                onChange={(e) =>
+                  setAccountInfo({ ...accountInfo, confirmPassword: e.target.value })
+                }
+              />
+              {editAccount && (
+                <>
+                  <span
+                    className="password-eye"
+                    onClick={() => setShowConfirmPassword((v) => !v)}
+                    title={showConfirmPassword ? "Ẩn mật khẩu" : "Hiện mật khẩu"}
+                  >
+                    {showConfirmPassword ? <AiOutlineEyeInvisible /> : <AiOutlineEye />}
+                  </span>
+                  {accountInfo.confirmPassword && (
+                    <span
+                      className="password-clear"
+                      onClick={clearConfirmPassword}
+                      title="Xóa mật khẩu"
+                    >
+                      <AiOutlineCloseCircle />
+                    </span>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+          <div className="account-actions">
+            {editAccount && (
+              <>
+                <button
+                  onClick={handleSaveAccount}
+                  disabled={loading}
+                  type="button"
+                >
+                  {loading ? "Đang lưu..." : "Lưu"}
+                </button>
+                <button
+                  onClick={() => {
+                    setEditAccount(false);
+                    setAccountInfo({
+                      username: account.username,
+                      newPassword: "",
+                      confirmPassword: "",
+                    });
+                  }}
+                  type="button"
+                  disabled={loading}
+                >
+                  Hủy
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/pages/Other/Account/index.js
+++ b/src/app/pages/Other/Account/index.js
@@ -1,0 +1,2 @@
+import Account from "./Account";
+export default Account;

--- a/src/app/pages/Other/ForgetPassword/ForgetPassword.css
+++ b/src/app/pages/Other/ForgetPassword/ForgetPassword.css
@@ -42,12 +42,22 @@
   border: 1px solid #ccc;
 }
 
-/* Quên mật khẩu */
 .forget-password-container .forget-password-left .register-link {
   align-self: flex-end;
   cursor: pointer;
   color: #c34141;
   margin-bottom: 10px;
+  background: none;
+  border: none;
+  font-size: 15px;
+  font-weight: 600;
+  text-decoration: underline;
+  padding: 0;
+}
+
+.forget-password-container .forget-password-left .register-link:disabled {
+  color: #aaa;
+  cursor: not-allowed;
 }
 
 /* Nút gửi mật khẩu */
@@ -63,13 +73,18 @@
 }
 .forget-password-container .forget-password-left .register-text {
   font-weight: 500;
+  margin-top: 18px;
 }
 
 /* Đăng ký */
-.forget-password-container .forget-password-left .register-text a {
+.forget-password-container .forget-password-left .register-text a,
+.forget-password-container .forget-password-left .register-text span {
   text-decoration: none;
   color: #c34141;
   cursor: pointer;
+}
+.forget-password-container .forget-password-left .register-text span:hover {
+  text-decoration: underline;
 }
 /* Bên phải */
 .forget-password-container .forget-password-right {

--- a/src/app/pages/Other/ForgetPassword/ForgetPassword.js
+++ b/src/app/pages/Other/ForgetPassword/ForgetPassword.js
@@ -1,42 +1,194 @@
-import background from "../../../assets/images/customer/login/background.png";
-import logo from "../../../assets/icons/admin/navigation/logo.png";
+import React, { useState, useRef, useEffect } from "react";
 import "./ForgetPassword.css";
+import logo from "../../../assets/icons/admin/navigation/logo.png";
+import background from "../../../assets/images/customer/login/background.png";
+import Swal from "sweetalert2";
+import withReactContent from "sweetalert2-react-content";
+import { fetchPost, fetchGet } from "../../../lib/httpHandler";
 import { useNavigate } from "react-router-dom";
 
+const MySwal = withReactContent(Swal);
+
 export default function ForgetPassword() {
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [canResend, setCanResend] = useState(true);
+  const [countdown, setCountdown] = useState(30);
+  const [accounts, setAccounts] = useState([]);
+  const [users, setUsers] = useState([]);
+  const timerRef = useRef(null);
   const navigate = useNavigate();
+
+  // Lấy danh sách account và user khi load trang
+  useEffect(() => {
+    fetchGet("/api/admin/account/get-all", (res) => setAccounts(res.data || []), () => setAccounts([]));
+    fetchGet("/api/admin/user/get-all", (res) => setUsers(res.data || []), () => setUsers([]));
+    return () => clearInterval(timerRef.current);
+  }, []);
+
+  // Validate email format
+  const isValidEmail = (mail) =>
+    /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/.test(mail);
+
+  // Đếm ngược 30s để gửi lại
+  const startCountdown = () => {
+    setCountdown(30);
+    setCanResend(false);
+    timerRef.current = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          clearInterval(timerRef.current);
+          setCanResend(true);
+          return 30;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  };
+
+  // Gửi lại mail
+  const handleResend = () => {
+    handleSendMail();
+  };
+
+  // Gửi mail đổi mật khẩu
+  const handleSendMail = () => {
+    if (!username || !email) {
+      MySwal.fire({
+        icon: "error",
+        title: "Lỗi",
+        text: "Vui lòng nhập đầy đủ thông tin!",
+      });
+      return;
+    }
+    if (!isValidEmail(email)) {
+      MySwal.fire({
+        icon: "error",
+        title: "Lỗi",
+        text: "Email không hợp lệ!",
+      });
+      return;
+    }
+    // Kiểm tra account và user
+    const account = accounts.find((a) => a.username === username);
+    if (!account) {
+      MySwal.fire({
+        icon: "error",
+        title: "Lỗi",
+        text: "Username không tồn tại!",
+      });
+      return;
+    }
+    const user = users.find(
+      (u) =>
+        u.account_id === account.id &&
+        u.email.trim().toLowerCase() === email.trim().toLowerCase()
+    );
+    if (!user) {
+      MySwal.fire({
+        icon: "error",
+        title: "Lỗi",
+        text: "Email không đúng với tài khoản!",
+      });
+      return;
+    }
+
+    // Hiển thị thành công ngay lập tức, disable nút gửi
+    startCountdown();
+    MySwal.fire({
+      icon: "success",
+      title: "Đã gửi email thành công!",
+      text: "Vui lòng kiểm tra email của bạn để lấy mật khẩu mới.",
+      confirmButtonText: "OK",
+    });
+
+    // Gọi API gửi mail ở background
+    fetchPost(
+      `/api/admin/account/change-password/${account.id}`,
+      {},
+      () => {},
+      () => {}
+    );
+  };
 
   return (
     <div className="forget-password-container">
       <div className="forget-password-left">
-        <img src={logo} alt="logo" className="logo"></img>
+        <img src={logo} alt="logo" className="logo" />
         <h1>Quên mật khẩu</h1>
-
-        <div className="forget-password-form">
-          <label>Tên đăng nhập</label>
-          <input type="text" placeholder="Nhập tên đăng nhập"></input>
-
-          <label>Email</label>
-          <input type="text" placeholder="Nhập email đăng ký "></input>
-
-          <div className="register-link" onClick={() => navigate("/login")}>
+        <form
+          className="forget-password-form"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (canResend) handleSendMail();
+          }}
+        >
+          <label htmlFor="username">Tên đăng nhập</label>
+          <input
+            id="username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="Nhập tên đăng nhập"
+            autoComplete="username"
+            disabled={!canResend}
+          />
+          <label htmlFor="email">Email đăng ký</label>
+          <input
+            id="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Nhập email đã đăng ký"
+            autoComplete="email"
+            type="email"
+            disabled={!canResend}
+          />
+          <button
+            type="submit"
+            className="email-button"
+            disabled={!canResend}
+            style={{
+              opacity: canResend ? 1 : 0.6,
+              cursor: canResend ? "pointer" : "not-allowed",
+            }}
+          >
+            Gửi email đặt lại mật khẩu
+          </button>
+        </form>
+        {!canResend && (
+          <div style={{ marginTop: 10 }}>
+            <span>
+              Bạn chưa nhận được email?{" "}
+              <button
+                onClick={handleResend}
+                disabled={countdown > 0}
+                className="register-link"
+                style={{
+                  background: "none",
+                  border: "none",
+                  color: "#c34141",
+                  fontWeight: 600,
+                  cursor: countdown > 0 ? "not-allowed" : "pointer",
+                  textDecoration: "underline",
+                  padding: 0,
+                }}
+              >
+                {countdown > 0 ? `Gửi lại sau ${countdown}s` : "Gửi lại"}
+              </button>
+            </span>
+          </div>
+        )}
+        <div className="register-text" style={{ marginTop: 18 }}>
+          Đã nhớ mật khẩu?{" "}
+          <span
+            style={{ color: "#c34141", cursor: "pointer", textDecoration: "underline" }}
+            onClick={() => navigate("/login")}
+          >
             Đăng nhập
-          </div>
-
-          <button className="email-button">Gửi mật khẩu qua email</button>
-
-          <div className="register-text">
-            Chưa có tài khoản? <a href="/register">Đăng ký tại đây</a>
-          </div>
+          </span>
         </div>
       </div>
-
       <div className="forget-password-right">
-        <img
-          src={background}
-          alt="Login background"
-          className="background-img"
-        />
+        <img src={background} alt="background" className="background-img" />
       </div>
     </div>
   );

--- a/src/app/routes/MainRoutes.js
+++ b/src/app/routes/MainRoutes.js
@@ -13,6 +13,7 @@ import Register from "../pages/Other/Register";
 import ForgetPassword from "../pages/Other/ForgetPassword";
 import Search from "../pages/Customer/Search";
 import CustomerMainPage from "../pages/Admin/CustomerManagement/CustomerMainPage";
+import Account from "../pages/Other/Account";
 
 export default function MainRoutes() {
   return (
@@ -22,7 +23,11 @@ export default function MainRoutes() {
         <Route path="/admin" element={<AdminLayout />}>
           <Route path="dashboard" index element={<Dashboard />} />
           <Route path="reports" element={<Report />} />
+          <Route path="account" element={<Account />} />
+          
+          {/* Nested routes for customer management and destination management */}
           <Route path="customers" element={<CustomerMainPage />} />
+          
           <Route
             path="destination-management"
             element={<DestinationMainPage />}
@@ -35,6 +40,7 @@ export default function MainRoutes() {
           <Route path="search" element={<Search />} />
           <Route path="login" element={<Login />}></Route>
           <Route path="register" element={<Register />}></Route>
+          <Route path="account" element={<Account />}></Route>
           <Route path="forget-password" element={<ForgetPassword />}></Route>
         </Route>
       </Routes>


### PR DESCRIPTION
Yêu cầu kéo này giới thiệu một số cải tiến cho bảng quản trị, tập trung vào việc cải thiện quản lý tiêu đề và phụ đề dựa trên ngữ cảnh, trải nghiệm người dùng cho tính năng "Quên mật khẩu" và cập nhật kiểu dáng. Ngoài ra, các phụ thuộc mới đã được thêm vào để hỗ trợ các hộp thoại tương tác.

### Quản lý tiêu đề và phụ đề dựa trên ngữ cảnh:

* **Bối cảnh bố cục quản trị**: Giới thiệu `AdminTitleContext` trong `AdminLayout` để quản lý tiêu đề và phụ đề động cho các trang quản trị.
* **Cập nhật tiêu đề quản trị**: Cập nhật `AdminHeader` để hiển thị tiêu đề và phụ đề động bằng `AdminTitleContext`. [[1]](diffhunk://#diff-c7d0285557240319cd0b6e602bd853152750ad87c217864235d5638cdd93ff46L1-R16) [[2]](diffhunk://#diff-c7d0285557240319cd0b6e602bd853152750ad87c217864235d5638cdd93ff46R38-R49)
* **Sử dụng ngữ cảnh cụ thể cho từng trang**: `AdminTitleContext` tích hợp trong `CustomerMainPage`, `Dashboard`, `DestinationMainPage` và `Report` để đặt tiêu đề và phụ đề cụ thể cho từng trang. [[1]](diffhunk://#diff-722de846aa92a809fd8b28d447eff77573e4c7b7589428993f971a413bf5dc87R13-R21) [[2]](diffhunk://#diff-ae0624ea5a39f5891fb2dbfa72974ea7f5dd8095b5b9d3fb8e04955c819d7cbcR169-R176) [[3]](diffhunk://#diff-872e2a4b9f936d625c3ae77e27fed7ed9ba79c420a13ce0d74a219742cc6108cR12-R18) [[4]](diffhunk://#diff-8174eace33e7609d9d71883f0ce5058ebe86e3685169e9d1374098125aed2b27R60-R66)

### Cải tiến tính năng "Quên mật khẩu":

* **Cải thiện chức năng**: Thêm xác thực email, xác minh tên người dùng/email và đếm ngược 30 giây gửi lại email đặt lại mật khẩu trong `ForgetPassword.js`.
* **Các hộp thoại tương tác**: `sweetalert2` và `sweetalert2-react-content` tích hợp để người dùng phản hồi tốt hơn trong các hành động đặt lại mật khẩu. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R19-R20) [[2]](diffhunk://#diff-adbbc567953060a6238ca6b56d2c5f4d17afa7b00d30c76c7dccdd9f7d8c4405L1-R191)

### Cập nhật kiểu dáng:

* **Kiểu dáng trang tài khoản**: Đã thêm kiểu dáng toàn diện cho trang quản lý tài khoản trong `Account.css`.
* **Trang Quên mật khẩu**: Cập nhật các kiểu cho các thành phần tương tác trong `ForgetPassword.css`. [[1]](diffhunk://#diff-60f273f8bdfec41320a2875924556962f0a74204b0abfc5750f4fad9c71704beL45-R60) [[2]](diffhunk://#diff-60f273f8bdfec41320a2875924556962f0a74204b0abfc5750f4fad9c71704beR76-R88)

### Các phụ thuộc mới:

* Đã thêm `sweetalert2` và `sweetalert2-react-content` để hỗ trợ các hộp thoại tương tác để người dùng phản hồi.

### Cập nhật định tuyến:

* Đã đăng ký trang `Tài khoản` mới trong các tuyến ứng dụng chính.